### PR TITLE
Added "android:name" to fragment tag

### DIFF
--- a/res/layout/activity_diary_panes.xml
+++ b/res/layout/activity_diary_panes.xml
@@ -12,6 +12,7 @@
 
     <fragment
             android:id="@+id/ItemList"
+            android:name="com.baasbox.deardiary.ui.NotesListFragment"
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"/>


### PR DESCRIPTION
Added "android:name" to fragment tag to solve issue "java.lang.RuntimeException: Unable to start activity ComponentInfo{com.baasbox.deardiary/com.baasbox.deardiary.ui.NoteListActivity}: android.view.InflateException: Binary XML file line #13: Error inflating class fragment"
